### PR TITLE
[feat] 파이널 프로젝트 디테일 구현

### DIFF
--- a/src/api/finaleAPI.ts
+++ b/src/api/finaleAPI.ts
@@ -30,7 +30,8 @@ export const createFinaleProjectAPI = async (req: {
 export const getFinaleProjectDetailAPI = async (req: {
     finaleProjectId: string;
 }): Promise<FinaleProjectDetailResponse> => {
-    return api.get(`/project/finale/${req.finaleProjectId}`);
+    const { data } = await api.get(`/project/finale/${req.finaleProjectId}`);
+    return data;
 };
 
 // 2-1. 파이널 프로젝트 팀 수정 -> 팀원만 가능 FinaleProjectTeamUpdate

--- a/src/components/templates/FinalProjectDetailCards.tsx
+++ b/src/components/templates/FinalProjectDetailCards.tsx
@@ -1,0 +1,53 @@
+import {
+    FinaleProjectBoard,
+} from '@/types/FinaleProject';
+import { ButtonPDF } from '../atoms';
+import { ProjectCard } from '../organisms';
+
+interface FinalProjectDetailCardsProps {
+    boards: Pick<
+        FinaleProjectBoard,
+        'id' | 'title' | 'createdAt' | 'thumbnail'
+    >[];
+    finaleProjectId: string;
+}
+
+const FinalProjectDetailCards = ({
+    boards,
+    finaleProjectId,
+}: FinalProjectDetailCardsProps) => {
+    const onClickPDF = (e: React.MouseEvent<HTMLButtonElement>) => {
+        console.log('PDF 다운로드', e);
+    };
+
+    return (
+        <div className="flex w-full flex-col gap-6 p-6">
+            <div className="flex w-full justify-end">
+                <ButtonPDF onClick={onClickPDF}></ButtonPDF>
+            </div>
+            {boards && boards.length > 0 ? (
+                <ul className="grid min-w-[1400px] grid-cols-4 grid-rows-2 gap-6">
+                    {boards.map((board) => (
+                        <li key={board.id}>
+                            <ProjectCard
+                                title={board.title}
+                                subTitle={board.createdAt}
+                                id={board.id}
+                                img={board.thumbnail}
+                                pathname={`/project/final/${finaleProjectId}/board`}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <div className="flex min-h-[200px] w-full items-center justify-center">
+                    <p className="text-lg text-gray-500">
+                        등록된 일지가 없습니다.
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default FinalProjectDetailCards;

--- a/src/components/templates/index.ts
+++ b/src/components/templates/index.ts
@@ -15,3 +15,4 @@ export { default as BMAlgorithmSolutionCards } from './BMAlgorithmSolutionCards'
 export { default as BMWebRecommendCards } from './BMWebRecommendCards';
 export { default as AlgoDetailCards } from './AlgoDetailCards';
 export { default as AlgoDetailCardSkeletonList } from './Skeletons/AlgoDetailCardSkeletonList';
+export { default as FinalProjectDetailCards } from './FinalProjectDetailCards';

--- a/src/pages/finalProject/FinalProjectBoardCreate.tsx
+++ b/src/pages/finalProject/FinalProjectBoardCreate.tsx
@@ -59,7 +59,7 @@ const FinalProjectBoardCreate = () => {
                 },
             });
 
-            navigate(`/project/final/${finalProjectId}/board/${id}`);
+            navigate(`/project/final/${finalProjectId}/board/${id.data.id}`);
         } catch (error) {
             console.error('게시글 작성을 실패했습니다:', error);
         }

--- a/src/pages/finalProject/FinalProjectBoardDetail.tsx
+++ b/src/pages/finalProject/FinalProjectBoardDetail.tsx
@@ -40,8 +40,6 @@ const FinalProjectBoardDetail = () => {
 
     return (
         <>
-            <div>팀 프로젝트 게시판 상세</div>
-
             <Header
             titleProps={{
                 title: data.title,

--- a/src/pages/finalProject/FinalProjectBoardUpdate.tsx
+++ b/src/pages/finalProject/FinalProjectBoardUpdate.tsx
@@ -87,7 +87,7 @@ const FinalProjectBoardUpdate = () => {
                 },
             });
 
-            navigate(`/project/final/${finalProjectId}/board/${id}`);
+            navigate(`/project/final/${finalProjectId}/board/${boardId}`);
         } catch (error) {
             console.error('게시글 수정을 실패했습니다:', error);
         }

--- a/src/pages/finalProject/FinalProjectDetail.tsx
+++ b/src/pages/finalProject/FinalProjectDetail.tsx
@@ -1,5 +1,136 @@
+
+import { Suspense } from 'react';
+import { Header } from '@/components/organisms';
+import { Button } from '@/components/atoms';
+import { ProjectCardSkeletonList } from '@/components/templates';
+import { useAuth } from '@/hooks/useAuth';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { useModalStore } from '@/stores/modalStore';
+import { FinalProjectDetailCards } from '@/components/templates';
+import { getFinaleProjectDetailAPI, deleteFinaleProjectAPI } from '@/api/finaleAPI';
+import { useQuery } from '@tanstack/react-query';
+import { FinaleTeamMember } from '@/types/FinaleProject';
+import { NameTag } from '@/components/atoms';
+
 const FinalProjectDetail = () => {
-    return <div>팀 프로젝트 상세</div>;
+    const { pathname } = useLocation();
+    const { finalProjectId } = useParams<{ finalProjectId: string }>();
+    const { userInfo } = useAuth();
+    const navigate = useNavigate();
+    const { openModal, closeModal } = useModalStore();
+
+    const { data: data } = useQuery({
+        queryKey: ['finaleProject', finalProjectId],
+        queryFn: async () => {
+            if (!finalProjectId) throw new Error('Project ID is required');
+            const data = await getFinaleProjectDetailAPI({ 
+                finaleProjectId: finalProjectId 
+            });
+            return data;
+        },
+        enabled: !!finalProjectId,
+    });
+
+    const isTeamMember = data?.members?.some(
+        member => member.id === userInfo?.userId
+    );
+    const isTeamLeader = data?.members?.some(
+        member => member.id === userInfo?.userId && member.role === 'LEADER'
+    );
+
+    const handleProjectDelete = () => {
+        if (!finalProjectId) return;
+        
+        openModal({
+            icon: 'warning',
+            title: '프로젝트 삭제',
+            subTitle: '정말 삭제하시겠습니까?',
+            onConfirmClick: async () => {
+                await deleteFinaleProjectAPI({ 
+                    finaleProjectId: finalProjectId 
+                });
+                navigate(-1);
+                closeModal();
+            },
+            onCancelClick: () => {
+                closeModal();
+            },
+        });
+    };
+
+    const handleProjectEdit = () => {
+        navigate('edit');
+    };
+
+    const handleCreateBoard = () => {
+        if (data?.finaleTeamId) {
+            navigate(`/project/final/${finalProjectId}/board/create`);
+        }
+    };
+
+    if (!data) {
+        return null;
+    }
+
+    return (
+        <>
+            <Header
+                titleProps={{ 
+                    title: data.title,
+                    subTitle: { '프로젝트 목표': data.description },
+                    description: { 'Git 주소': data.url },
+                    isLink: true,
+                }}
+                BreadcrumbProps={{ pathname }}
+            >
+                <div className="flex justify-between">
+                <div className="flex gap-3">
+                    {data.members.map(
+                        (
+                            member: Pick<
+                                FinaleTeamMember,
+                                'id' | 'name' | 'role'
+                            >,
+                        ) => (
+                            <NameTag key={member.id} isLeader={member.role}>
+                                {member.name}
+                            </NameTag>
+                        ),
+                    )}
+                </div>
+                    {(userInfo?.role === 'ADMIN' || isTeamMember || isTeamLeader) && (
+                        <section className="flex gap-4">
+                            {(userInfo?.role === 'ADMIN' || isTeamLeader || isTeamMember) && (
+                                <>
+                                    <Button color="red" onClick={handleProjectDelete}>
+                                        프로젝트 삭제
+                                    </Button>
+                                    <Button onClick={handleProjectEdit}>
+                                        프로젝트 수정
+                                    </Button>
+                                </>
+                            )}
+                            {(isTeamLeader || isTeamMember) && (
+                                <Button onClick={handleCreateBoard}>
+                                    일지 작성
+                                </Button>
+                            )}
+                        </section>
+                    )}
+                </div>
+            </Header>
+
+            <Suspense fallback={<ProjectCardSkeletonList />}>
+                {data.boards && (
+                    <FinalProjectDetailCards
+                        boards={data.boards}
+                        finaleProjectId={finalProjectId!}
+                    />
+                )}
+            </Suspense>
+        </>
+    );
 };
+
 
 export default FinalProjectDetail;


### PR DESCRIPTION
## #️⃣ Issue Number

closes #164

## 📝 요약(Summary)

- 파이널 프로젝트 팀 데일리 일지 작성/수정 후 리다이렉션 경로 수정
- 팀 프로젝트 게시판 상세에서 불필요한 div 태그 삭제
- getFinaleProjectDetailAPI 응답에서 data 객체 추출
- 파이널 프로젝트 디테일 구현
  -  git 주소에 a태그 적용
  - 프로젝트 수정 삭제 어드민 & 팀원에게만 버튼 렌더링
  - 일지 작성 팀원에게만 버튼 렌더링

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
