### PR TITLE
[style] 모든 리스트 페이지 내부 영역 고정 넓이로 레이아웃 수정

### DIFF
--- a/src/components/templates/AlgoDetailCards.tsx
+++ b/src/components/templates/AlgoDetailCards.tsx
@@ -117,7 +117,7 @@ const AlgoDetailCards = ({ problemId }: AlgoDetailCardsProps) => {
             <div className="flex w-[1400px] flex-col items-center justify-center gap-6 p-6">
                 {data?.content?.length ? (
                     <>
-                        <ul className="grid w-full grid-cols-3 grid-rows-3 gap-6">
+                        <ul className="grid w-[1400px] grid-cols-3 grid-rows-3 gap-6">
                             {data.content.map((item) => (
                                 <li key={item.id}>
                                     <AlgoDetailCard

--- a/src/components/templates/AlgoProblemCards.tsx
+++ b/src/components/templates/AlgoProblemCards.tsx
@@ -66,7 +66,7 @@ const AlgoProblemCards = () => {
             </div>
             {data?.content?.length ? (
                 <>
-                    <ul className="grid w-full grid-cols-4 grid-rows-4 gap-6">
+                    <ul className="grid w-[1400px] grid-cols-4 grid-rows-4 gap-6">
                         {data.content.map((item) => (
                             <li key={item.id}>
                                 <AlgoProblemCard

--- a/src/components/templates/AlgorithmGuideCards.tsx
+++ b/src/components/templates/AlgorithmGuideCards.tsx
@@ -56,7 +56,7 @@ const AlgorithmGuideCards = ({ generationId }: AlgorithmGuideCardsProps) => {
             </div>
             {data?.content?.length ? (
                 <>
-                    <ul className="grid min-w-[1400px] grid-cols-4 grid-rows-2 gap-6">
+                    <ul className="grid w-[1400px] grid-cols-4 grid-rows-2 gap-6">
                         {data.content.map((item) => (
                             <li key={item.id}>
                                 <ProjectCard

--- a/src/components/templates/FinalListCard.tsx
+++ b/src/components/templates/FinalListCard.tsx
@@ -15,7 +15,7 @@ interface FinalListCardsProps {
 const FinalListCards = ({ boards }: FinalListCardsProps) => {
     const { pathname } = useLocation();
     return (
-        <div className="flex w-full flex-col gap-6 p-6">
+        <div className="flex w-full flex-col items-center gap-6 p-6">
             {boards && boards.length > 0 ? (
                 <>
                     <ul className="grid min-w-[1400px] grid-cols-4 grid-rows-2 gap-6">

--- a/src/components/templates/FinalProjectDetailCards.tsx
+++ b/src/components/templates/FinalProjectDetailCards.tsx
@@ -21,12 +21,12 @@ const FinalProjectDetailCards = ({
     };
 
     return (
-        <div className="flex w-full flex-col gap-6 p-6">
+        <div className="flex w-full flex-col items-center gap-6 p-6">
             <div className="flex w-full justify-end">
                 <ButtonPDF onClick={onClickPDF}></ButtonPDF>
             </div>
             {boards && boards.length > 0 ? (
-                <ul className="grid min-w-[1400px] grid-cols-4 grid-rows-2 gap-6">
+                <ul className="grid w-[1400px] grid-cols-4 grid-rows-2 gap-6">
                     {boards.map((board) => (
                         <li key={board.id}>
                             <ProjectCard

--- a/src/components/templates/TrackProjectCards.tsx
+++ b/src/components/templates/TrackProjectCards.tsx
@@ -33,13 +33,13 @@ const TrackProjectCards = ({
     };
 
     return (
-        <div className="flex w-full flex-col gap-6 p-6">
+        <div className="flex w-full flex-col gap-6 p-6 items-center">
             <div className="flex w-full justify-end">
                 <ButtonPDF onClick={onClickPDF}></ButtonPDF>
             </div>
             {boards && boards.length > 0 ? (
                 <>
-                    <ul className="grid min-w-[1400px] grid-cols-4 grid-rows-2 gap-6">
+                    <ul className="grid w-[1400px] grid-cols-4 grid-rows-2 gap-6">
                         {boards.map((board) => {
                             const foundTeam = teams.find((team) => {
                                 // 팀의 members 배열에서 boards.members.id와 일치하는 항목이 있는지 확인

--- a/src/components/templates/WebRecommendCards.tsx
+++ b/src/components/templates/WebRecommendCards.tsx
@@ -56,7 +56,7 @@ const WebRecommendCards = ({ generationId }: WebRecommendCardsProps) => {
             </div>
             {data?.content?.length ? (
                 <>
-                    <ul className="grid min-w-[1600px] grid-cols-4 grid-rows-4 gap-6">
+                    <ul className="grid min-w-[1400px] grid-cols-4 grid-rows-4 gap-6">
                         {data.content.map((i) => (
                             <li key={i.id}>
                                 <WebSiteCard

--- a/src/pages/finalProject/FinalProjectList.tsx
+++ b/src/pages/finalProject/FinalProjectList.tsx
@@ -41,7 +41,7 @@ const FinalProjectList = () => {
     );
 
     return (
-        <>
+        <div className='flex flex-col items-center'>
             <Header
                 titleProps={{ title: '파이널 프로젝트' }}
                 BreadcrumbProps={{ pathname }}
@@ -74,8 +74,8 @@ const FinalProjectList = () => {
                 </div>
             </Header>
 
-            <section className="m-4 mt-6 border bg-white p-4">
-                <section className="flex flex-wrap gap-2">
+            <section className="flex m-4 mt-6 border bg-white p-4 w-[1400px]">
+                <section className="flex flex-wrap gap-2 ">
                     <SubmitSection
                         project="final"
                         teams={data?.teams}
@@ -85,12 +85,12 @@ const FinalProjectList = () => {
                 </section>
             </section>
 
-            <section className="grid w-full grid-cols-1 gap-6 p-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            <section >
                 <Suspense fallback={<ProjectCardSkeletonList />}>
                     <FinalListCards boards={data?.projects} />
                 </Suspense>
             </section>
-        </>
+        </div>
     );
 };
 

--- a/src/pages/music/SearchMusic.tsx
+++ b/src/pages/music/SearchMusic.tsx
@@ -91,7 +91,7 @@ const SearchMusic = () => {
     }, [isQuotaExceeded]);
 
     return (
-        <>
+        <div className='flex flex-col items-center'>
             <Header
                 titleProps={{ title: '노래 신청' }}
                 BreadcrumbProps={{ pathname }}
@@ -106,7 +106,7 @@ const SearchMusic = () => {
                     onChange={handleChange}
                 />
             </div>
-            <div className="grid grid-cols-3 gap-4 px-[85px]">
+            <div className="grid w-[1400px] grid-cols-3 gap-4 px-[85px]">
                 {data ? (
                     data.pages.map((page) =>
                         page.items.map((item) => (
@@ -158,7 +158,7 @@ const SearchMusic = () => {
                         )}
                 </div>
             </div>
-        </>
+        </div>
     );
 };
 

--- a/src/pages/trackProject/TrackProjectDetail.tsx
+++ b/src/pages/trackProject/TrackProjectDetail.tsx
@@ -81,7 +81,7 @@ const TrackProjectDetail = () => {
     };
 
     return (
-        <>
+        <div className='flex flex-col items-center'>
             <Header
                 titleProps={{
                     title: data?.title,
@@ -119,7 +119,7 @@ const TrackProjectDetail = () => {
                 </div>
             </Header>
 
-            <section className="m-4 mt-6 border bg-white p-4">
+            <section className="flex m-4 mt-6 border bg-white p-4 w-[1400px]">
                 <section className="flex flex-wrap gap-2">
                     <SubmitSection
                         project="track"
@@ -137,7 +137,7 @@ const TrackProjectDetail = () => {
                     boards={data?.boards}
                 ></TrackProjectCards>
             </Suspense>
-        </>
+        </div>
     );
 };
 

--- a/src/pages/trackProject/TrackProjectList.tsx
+++ b/src/pages/trackProject/TrackProjectList.tsx
@@ -71,8 +71,8 @@ const TrackProjectList = () => {
                     </div>
                 </div>
             </Header>
-
-            <section className="grid w-full grid-cols-1 gap-6 p-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            <div className="flex flex-col items-center">
+            <section className="grid min-w-[1400px] grid-cols-4 gap-6 p-6">
                 {/* Suspense로 로딩 상태 처리 */}
                 <Suspense fallback={<ProjectCardSkeletonList />}>
                     {projectList && projectList.length > 0 ? (
@@ -93,6 +93,7 @@ const TrackProjectList = () => {
                     )}
                 </Suspense>
             </section>
+        </div>
         </>
     );
 };


### PR DESCRIPTION
## #️⃣ Issue Number

related #180, #181, #182, #183, #185


## 📝 요약(Summary)

모든 리스트 렌더링 페이지의 내부 영역을 1400px으로 고정하고, 중앙 정렬로 레이아웃의 통일성을 주었습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
