### PR TITLE
[fix] 관리자 게시글 수정 삭제 버튼 렌더링, 관통 프로젝트 삭제 후 프로젝트 리스트로 리다이렉션, 관통 프로젝트 일지 깃 주소 url 링크 적용, 웹 개념 게시글 수정 권한 변경

### DIFF
--- a/src/components/molecules/Title/Title.tsx
+++ b/src/components/molecules/Title/Title.tsx
@@ -62,9 +62,24 @@ const Title = ({
                             <h3 className="whitespace-nowrap text-xl font-semibold text-gray-900">
                                 {key}
                             </h3>
-                            <p className="break-words text-xl font-medium text-gray-900">
-                                {value}
-                            </p>
+                            {isLink ? (
+                                <a
+                                    href={
+                                        value.startsWith('http')
+                                            ? value
+                                            : `https://${value}`
+                                    }
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xl block truncate font-medium text-blue-600"
+                                >
+                                    {value}
+                                </a>
+                            ) : (
+                                <p className="text-xl break-words font-medium text-gray-900">
+                                    {value}
+                                </p>
+                            )}
                         </div>
                     ))}
 

--- a/src/pages/algorithmSolution/AlgorithmSolutionDetail.tsx
+++ b/src/pages/algorithmSolution/AlgorithmSolutionDetail.tsx
@@ -25,6 +25,8 @@ const AlgorithmSolutionDetail = () => {
 
     const { userInfo } = useAuth();
     const userId = userInfo?.userId;
+    const isAdmin = userInfo?.role === 'ADMIN';
+    const isAuthor = data?.authorId === userId;
 
     if (!data) return null;
 
@@ -48,7 +50,7 @@ const AlgorithmSolutionDetail = () => {
                         readOnly={true}
                     />
                     <div className="flex gap-4">
-                        {userId == data.authorId && (
+                        {(isAdmin || isAuthor) && (
                             <div className="flex gap-4">
                                 <Button color="red" onClick={handleDelete}>
                                     풀이 삭제

--- a/src/pages/trackProject/TrackProjectBoardDetail.tsx
+++ b/src/pages/trackProject/TrackProjectBoardDetail.tsx
@@ -44,6 +44,7 @@ const TrackProjectBoardDetail = () => {
                 titleProps={{
                     title: data.title,
                     subTitle: { 'Git 주소': data.url },
+                    isLink: true,
                 }}
                 BreadcrumbProps={{ pathname }}
             >

--- a/src/pages/trackProject/TrackProjectDetail.tsx
+++ b/src/pages/trackProject/TrackProjectDetail.tsx
@@ -44,7 +44,7 @@ const TrackProjectDetail = () => {
             subTitle: '정말 삭제하시겠습니까?',
             onConfirmClick: async () => {
                 await deleteTrackProjectAPI(trackProjectId!);
-                navigate(-1);
+                navigate('/project/track');
                 closeModal();
             },
             onCancelClick: () => {

--- a/src/pages/webGuide/WebGuideDetail.tsx
+++ b/src/pages/webGuide/WebGuideDetail.tsx
@@ -10,7 +10,6 @@ const WebGuideDetail = () => {
     const { pathname } = useLocation();
     const { guideId } = useParams();
     const { userInfo } = useAuth();
-    const userId = userInfo?.userId;
     const userRole = userInfo?.role;
 
     const { data, handleDelete, handleEdit, handleLike } = useContentDetail({
@@ -41,7 +40,7 @@ const WebGuideDetail = () => {
                             </Button>
                         )}
 
-                        {userId === data.authorId && (
+                        {userRole === 'ADMIN' && (
                             <Button onClick={handleEdit}>글 수정</Button>
                         )}
                     </div>

--- a/src/pages/webRecommend/WebRecommendDetail.tsx
+++ b/src/pages/webRecommend/WebRecommendDetail.tsx
@@ -26,6 +26,7 @@ const WebRecommendDetail = () => {
     
     const userId = userInfo?.userId;
     const isAuthor = data.authorId === userId;
+    const isAdmin = userInfo?.role === 'ADMIN';
 
     return (
         <>
@@ -39,7 +40,7 @@ const WebRecommendDetail = () => {
                 }}
                 BreadcrumbProps={{ pathname }}
             >
-                {isAuthor && (
+                {(isAdmin || isAuthor) && (
                     <div className="flex justify-end">
                         <div className="flex gap-4">
                             <Button color="red" onClick={handleDelete}>


### PR DESCRIPTION
## #️⃣ Issue Number

closes #205 #206 #207 #212

## 📝 요약(Summary)

- 웹 추천 디테일, 알고리즘 문제 풀이 디테일에서 관리자에게 게시글 삭제, 수정 버튼 렌더링 안 되던 부분 수정했습니다.
- 관통 프로젝트 삭제 후 이전 페이지로 이동하던 부분 프로젝트 리스트로 이동하도록 수정했습니다.
- 관통 프로젝트 일지 깃 주소에 URL 링크 적용했습니다.
- 웹 개념 본인 게시글이 아니면 관리자에게 수정 버튼 렌더링 안 되던 부분 수정했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
